### PR TITLE
Add SiWx917 GPIO, IR Sensor community projects

### DIFF
--- a/projects/wifi/wifi_applications/README.md
+++ b/projects/wifi/wifi_applications/README.md
@@ -38,7 +38,7 @@ Example row (copy/paste and edit):
 | Project (GitHub) | Description | Author/Contributor |
 |:--|:--|:--|
 | [SiWx917 External LED Blink](https://github.com/ab8642/siwx917-led-blink) | Blinks an external LED on SiWx917 (BRD2605A) using the Si91x GPIO driver and sleep timer via Simplicity Studio 5. | [ab8642](https://github.com/ab8642) |
-| [SiWx917 IR Sensor](https://github.com/ab8642/siwx917-ir-sensor) | IR sensor interfacing on SiWx917 (BRD2605A) using the Si91x GPIO driver for object detection with serial output via Simplicity Studio 5. | [ab8642](https://github.com/ab8642) |
+| [SiWx917 IR Sensor](https://github.com/ab8642/siwx917_IRsensor) | IR sensor interfacing on SiWx917 (BRD2605A) using the Si91x GPIO driver for object detection with serial output via Simplicity Studio 5. | [ab8642](https://github.com/ab8642) |
 ## Documentation ##
 
 The official Wi-Fi documentation is available on the [Developer Documentation](https://docs.silabs.com/wiseconnect/latest/wiseconnect-developing-with-wiseconnect-sdk/) page.

--- a/projects/wifi/wifi_applications/README.md
+++ b/projects/wifi/wifi_applications/README.md
@@ -37,7 +37,8 @@ Example row (copy/paste and edit):
 
 | Project (GitHub) | Description | Author/Contributor |
 |:--|:--|:--|
-
+| [SiWx917 External LED Blink](https://github.com/ab8642/siwx917-led-blink) | Blinks an external LED on SiWx917 (BRD2605A) using the Si91x GPIO driver and sleep timer via Simplicity Studio 5. | [ab8642](https://github.com/ab8642) |
+| [SiWx917 IR Sensor](https://github.com/ab8642/siwx917-ir-sensor) | IR sensor interfacing on SiWx917 (BRD2605A) using the Si91x GPIO driver for object detection with serial output via Simplicity Studio 5. | [ab8642](https://github.com/ab8642) |
 ## Documentation ##
 
 The official Wi-Fi documentation is available on the [Developer Documentation](https://docs.silabs.com/wiseconnect/latest/wiseconnect-developing-with-wiseconnect-sdk/) page.


### PR DESCRIPTION
## Description
Add SiWx917 GPIO, IR Sensor community projects

## Project GitHub URL
- https://github.com/ab8642/siwx917-led-blink
- https://github.com/ab8642/siwx917_IRsensor

## Checklist
- [x] I have read the [Contributor License Agreement](https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/contributor_license_agreement.md).
- [x] The linked GitHub repository is public and accessible.
- [x] The linked GitHub repository includes a license file.
- [x] I added my entry to the correct category listing table under `projects/` (appended at the bottom; did not reorder existing rows).

## Additional Notes
both projects use the WiSeConnect 3 SDK with sl_si91x_driver_gpio and sl_sleeptimer components via Simplicity Studio 5.
